### PR TITLE
Add --date option and revert ingestion changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ ctbus_finance ingest_csv account_holdings_YYYY_MM_DD.csv account_holdings
 ctbus_finance ingest_csv credit_card_holdings_YYYY_MM_DD.csv credit_card_holdings
 ```
 
-Note that it will fill in today's date for `date` unless it is specified in the CSV. It will also try to fill purchase_price for each asset from previous entries (especially useful if you have things Yahoo finance can't identify, so it won't keep looking that up and failing).
+Use the optional `--date` argument to apply a specific date to all rows when your CSV doesn't include one:
+
+```
+ctbus_finance ingest_csv account_holdings_2024_01_01.csv account_holdings --date 2024-01-01
+```
+
+Note that it will fill in today's date for `date` unless it is specified in the CSV or provided via the `--date` option. It will also try to fill purchase_price for each asset from previous entries (especially useful if you have things Yahoo finance can't identify, so it won't keep looking that up and failing).
 
 ### Web interface
 

--- a/ctbus_finance/cli.py
+++ b/ctbus_finance/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import sys
+from datetime import datetime
 from ctbus_finance import __version__
 from ctbus_finance.db import create_database, ingest_csv
 from pathlib import Path
@@ -45,6 +46,11 @@ def main():
             "type",
             help="Type of the CSV file (e.g., accounts, holdings, account_holdings).",
         )
+        ingest_csv_parser.add_argument(
+            "--date",
+            help="Default date (YYYY-MM-DD) to use if date column is missing.",
+            default=datetime.today().strftime("%Y-%m-%d"),
+        )
         ingest_csv_args = ingest_csv_parser.parse_args(remaining)
 
         if not ingest_csv_args.file_path:
@@ -66,7 +72,14 @@ def main():
             sys.stderr.write(f"Type {ingest_csv_args.type} is not recognized.\n")
             sys.exit(1)
 
-        ingest_csv(fp=Path(ingest_csv_args.file_path), table=ingest_csv_args.type)
+        default_date = datetime.strptime(
+            ingest_csv_args.date, "%Y-%m-%d"
+        ).date()
+        ingest_csv(
+            fp=Path(ingest_csv_args.file_path),
+            table=ingest_csv_args.type,
+            default_date=default_date,
+        )
     else:
         parser.print_help()
         sys.stderr.write("Unrecognized command.\n")


### PR DESCRIPTION
## Summary
- revert prior ingestion append commit
- allow specifying ingestion date with new `--date` flag
- document `--date` usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a3d8ed0888323afd77de6f5034a79