### PR TITLE
Reduce Yahoo Finance rate limit errors

### DIFF
--- a/ctbus_finance/yahoo_finance.py
+++ b/ctbus_finance/yahoo_finance.py
@@ -1,8 +1,15 @@
 import time
 from datetime import datetime, timedelta
+from typing import Iterable, Dict
 
 import yfinance as yf
 from yfinance.exceptions import YFRateLimitError
+
+# cache to store price lookups so we only hit the network once per
+# (ticker, date) pair. This drastically reduces the number of requests
+# made to Yahoo Finance which helps avoid hitting rate limits when
+# ingesting large CSV files.
+_PRICE_CACHE: Dict[tuple[str, datetime.date], float] = {}
 
 
 def get_ticker_data(ticker: str) -> yf.Ticker:
@@ -21,6 +28,53 @@ def get_ticker_data(ticker: str) -> yf.Ticker:
         raise ValueError(f"Error fetching data for ticker {ticker}: {e}")
 
 
+def get_prices_batch(ticker: str, dates: Iterable[datetime]) -> None:
+    """Populate the cache with prices for the given ticker and dates.
+
+    This performs a single Yahoo Finance request for all dates and stores
+    the results in ``_PRICE_CACHE``. Subsequent calls to :func:`get_price`
+    will use the cached values.
+
+    Parameters
+    ----------
+    ticker : str
+        The asset symbol to fetch.
+    dates : Iterable[datetime]
+        Collection of dates that need prices.
+    """
+
+    unique_dates = sorted({d.date() for d in dates})
+    if not unique_dates:
+        return
+
+    start = min(unique_dates) - timedelta(days=1)
+    end = max(unique_dates) + timedelta(days=2)
+
+    attempts = 0
+    while True:
+        try:
+            df = yf.download(ticker, start=start, end=end, progress=False)
+            break
+        except YFRateLimitError:
+            attempts += 1
+            if attempts >= 3:
+                raise
+            time.sleep(1)
+        except Exception:
+            attempts += 1
+            if attempts >= 3:
+                raise
+            time.sleep(1)
+
+    for d in unique_dates:
+        if (ticker, d) in _PRICE_CACHE:
+            continue
+        subset = df[df.index.date <= d]
+        if not subset.empty:
+            last_idx = subset.index[-1]
+            _PRICE_CACHE[(ticker, d)] = round(subset.loc[last_idx]["Close"], 2)
+
+
 def get_price(
     ticker: yf.Ticker,
     date: datetime,
@@ -37,28 +91,31 @@ def get_price(
     Returns:
     float: The price of the ticker.
     """
-    attempts = 0
-    while True:
-        try:
-            df = ticker.history(
-                start=date - timedelta(days=1), end=date + timedelta(days=2)
-            )
-            break
-        except YFRateLimitError:
-            attempts += 1
-            if attempts >= max_retries:
-                raise
-            time.sleep(retry_delay)
-        except Exception:
-            attempts += 1
-            if attempts >= max_retries:
-                raise
-            time.sleep(retry_delay)
+    key = (ticker.ticker if hasattr(ticker, "ticker") else str(ticker), date.date())
+    if key not in _PRICE_CACHE:
+        attempts = 0
+        while True:
+            try:
+                df = ticker.history(
+                    start=date - timedelta(days=1), end=date + timedelta(days=2)
+                )
+                break
+            except YFRateLimitError:
+                attempts += 1
+                if attempts >= max_retries:
+                    raise
+                time.sleep(retry_delay)
+            except Exception:
+                attempts += 1
+                if attempts >= max_retries:
+                    raise
+                time.sleep(retry_delay)
 
-    if date in df.index:
-        return round(df.loc[date]["Close"], 2)
-    else:
-        # Iterate through the DataFrame and return the first available price
-        for index in df.index:
-            if index.date() <= date.date():
-                return round(df.loc[index]["Close"], 2)
+        if date in df.index:
+            _PRICE_CACHE[key] = round(df.loc[date]["Close"], 2)
+        else:
+            for index in df.index:
+                if index.date() <= date.date():
+                    _PRICE_CACHE[key] = round(df.loc[index]["Close"], 2)
+                    break
+    return _PRICE_CACHE[key]

--- a/ctbus_finance/yahoo_finance.py
+++ b/ctbus_finance/yahoo_finance.py
@@ -118,4 +118,8 @@ def get_price(
                 if index.date() <= date.date():
                     _PRICE_CACHE[key] = round(df.loc[index]["Close"], 2)
                     break
+            else:
+                raise ValueError(
+                    f"No valid price data found for ticker {ticker.ticker if hasattr(ticker, 'ticker') else str(ticker)} on or before {date.date()}."
+                )
     return _PRICE_CACHE[key]


### PR DESCRIPTION
## Summary
- cache price lookups in `yahoo_finance.py`
- add `get_prices_batch` to fetch prices for a ticker in one request
- batch requests in `process_account_holdings`

## Testing
- `ruff check ctbus_finance/yahoo_finance.py ctbus_finance/db.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a4a19692c8323aea5e504f8391cb4