### PR TITLE
Fix incompatible indexer error in ingestion

### DIFF
--- a/ctbus_finance/db.py
+++ b/ctbus_finance/db.py
@@ -161,16 +161,16 @@ def process_account_holdings(
 
     for index, row in df.iterrows():
         print(row["account_id"], row["holding_id"], row["purchase_date"])
-        df.loc[index, "quantity"] = float(row["quantity"])
+        df.at[index, "quantity"] = float(row["quantity"])
         if pd.isna(row["date"]):
-            df.loc[index, "date"] = default_date
+            df.at[index, "date"] = default_date
         if pd.isna(row["price"]):
             ticker = get_ticker_data(row["holding_id"])
-            df.loc[index, "price"] = get_price(
-                ticker, pd.to_datetime(df.loc[index, "date"])
+            df.at[index, "price"] = get_price(
+                ticker, pd.to_datetime(df.at[index, "date"])
             )
             if pd.notna(row["purchase_date"]):
-                df.loc[index, "purchase_date"] = datetime.strptime(
+                df.at[index, "purchase_date"] = datetime.strptime(
                     row["purchase_date"], "%Y-%m-%d"
                 ).date()
                 if res := session.scalars(
@@ -180,9 +180,9 @@ def process_account_holdings(
                     )
                     .filter(AccountHolding.purchase_price.is_not(None))
                 ).first():
-                    df.loc[index, "purchase_price"] = float(res)
+                    df.at[index, "purchase_price"] = float(res)
                 else:
-                    df.loc[index, "purchase_price"] = get_price(
+                    df.at[index, "purchase_price"] = get_price(
                         ticker, pd.to_datetime(row["purchase_date"])
                     )
     dates = df.pop("date")
@@ -222,7 +222,7 @@ def process_credit_card_holdings(
     print("Processing credit card holdings...")
     for index, row in df.iterrows():
         print(row["credit_card_id"], row["balance"], row["rewards"])
-        df.loc[index, "balance"] = float(row["balance"])
-        df.loc[index, "date"] = default_date
+        df.at[index, "balance"] = float(row["balance"])
+        df.at[index, "date"] = default_date
 
     return df

--- a/ctbus_finance/yahoo_finance.py
+++ b/ctbus_finance/yahoo_finance.py
@@ -66,6 +66,7 @@ def get_prices_batch(ticker: str, dates: Iterable[datetime]) -> None:
                 raise
             time.sleep(1)
 
+    success_count = 0
     for d in unique_dates:
         if (ticker, d) in _PRICE_CACHE:
             continue
@@ -73,6 +74,11 @@ def get_prices_batch(ticker: str, dates: Iterable[datetime]) -> None:
         if not subset.empty:
             last_idx = subset.index[-1]
             _PRICE_CACHE[(ticker, d)] = round(subset.loc[last_idx]["Close"], 2)
+            success_count += 1
+
+    print(
+        f"Yahoo Finance: retrieved {success_count}/{len(unique_dates)} prices for {ticker}"
+    )
 
 
 def get_price(


### PR DESCRIPTION
## Summary
- fix pandas series assignment error by using `at` instead of `loc`
- print number of price lookups retrieved in Yahoo Finance batch requests

## Testing
- `python -m py_compile ctbus_finance/db.py ctbus_finance/yahoo_finance.py`
- `python - <<'EOF'
import sys
sys.argv = ["ctbus_finance", "ingest_csv", "example_data/account_holdings_2024_01_01.csv", "account_holdings", "--date", "2024-01-01"]
import ctbus_finance.cli
ctbus_finance.cli.main()
EOF`
- `python - <<'EOF'
from datetime import datetime
from ctbus_finance.yahoo_finance import get_prices_batch
get_prices_batch('AAPL', [datetime(2024,1,1), datetime(2024,2,1)])
EOF`


------
https://chatgpt.com/codex/tasks/task_e_684aed442cc0832390dd58159bf84abf