### PR TITLE
Refactor price lookups to enforce single-day data

### DIFF
--- a/ctbus_finance/account_holding.py
+++ b/ctbus_finance/account_holding.py
@@ -1,4 +1,3 @@
-import pandas as pd
 from ctbus_finance.db import get_session
 from ctbus_finance.models import AccountHolding, Holding
 from ctbus_finance.yahoo_finance import get_ticker_data, get_price

--- a/ctbus_finance/yahoo_finance.py
+++ b/ctbus_finance/yahoo_finance.py
@@ -1,6 +1,6 @@
 import time
 from datetime import datetime, timedelta
-from typing import Iterable, Dict
+from typing import Iterable, Dict, List
 
 import yfinance as yf
 from yfinance.exceptions import YFRateLimitError
@@ -47,22 +47,21 @@ def get_prices_batch(ticker: str, dates: Iterable[datetime]) -> None:
     if not unique_dates:
         return
 
-    start = min(unique_dates) - timedelta(days=1)
-    end = max(unique_dates) + timedelta(days=2)
+    for d in unique_dates:
+        if d.weekday() >= 5:
+            raise ValueError(f"{d} is not a trading day")
+
+    start = min(unique_dates)
+    end = max(unique_dates) + timedelta(days=1)
 
     attempts = 0
     while True:
         try:
             df = yf.download(ticker, start=start, end=end, progress=False)
             break
-        except YFRateLimitError:
-            attempts += 1
-            if attempts >= 3:
-                raise
-            time.sleep(1)
         except Exception:
             attempts += 1
-            if attempts >= 3:
+            if attempts >= 2:
                 raise
             time.sleep(1)
 
@@ -70,11 +69,10 @@ def get_prices_batch(ticker: str, dates: Iterable[datetime]) -> None:
     for d in unique_dates:
         if (ticker, d) in _PRICE_CACHE:
             continue
-        subset = df[df.index.date <= d]
-        if not subset.empty:
-            last_idx = subset.index[-1]
-            _PRICE_CACHE[(ticker, d)] = round(subset.loc[last_idx]["Close"], 2)
-            success_count += 1
+        if d not in df.index.date:
+            raise ValueError(f"No price data for {ticker} on {d}")
+        _PRICE_CACHE[(ticker, d)] = round(df.loc[str(d)]["Close"], 2)
+        success_count += 1
 
     print(
         f"Yahoo Finance: retrieved {success_count}/{len(unique_dates)} prices for {ticker}"
@@ -84,7 +82,7 @@ def get_prices_batch(ticker: str, dates: Iterable[datetime]) -> None:
 def get_price(
     ticker: yf.Ticker,
     date: datetime,
-    max_retries: int = 3,
+    max_retries: int = 1,
     retry_delay: float = 1.0,
 ) -> float:
     """
@@ -99,33 +97,75 @@ def get_price(
     """
     key = (ticker.ticker if hasattr(ticker, "ticker") else str(ticker), date.date())
     if key not in _PRICE_CACHE:
+        if date.weekday() >= 5:
+            raise ValueError(f"{date.date()} is not a trading day")
+
         attempts = 0
         while True:
             try:
-                df = ticker.history(
-                    start=date - timedelta(days=1), end=date + timedelta(days=2)
+                df = yf.download(
+                    ticker.ticker if hasattr(ticker, "ticker") else str(ticker),
+                    start=date,
+                    end=date + timedelta(days=1),
+                    progress=False,
                 )
                 break
-            except YFRateLimitError:
-                attempts += 1
-                if attempts >= max_retries:
-                    raise
-                time.sleep(retry_delay)
             except Exception:
                 attempts += 1
-                if attempts >= max_retries:
+                if attempts > max_retries:
                     raise
                 time.sleep(retry_delay)
 
-        if date in df.index:
-            _PRICE_CACHE[key] = round(df.loc[date]["Close"], 2)
-        else:
-            for index in df.index:
-                if index.date() <= date.date():
-                    _PRICE_CACHE[key] = round(df.loc[index]["Close"], 2)
-                    break
-            else:
-                raise ValueError(
-                    f"No valid price data found for ticker {ticker.ticker if hasattr(ticker, 'ticker') else str(ticker)} on or before {date.date()}."
-                )
+        if date not in df.index:
+            raise ValueError(
+                f"No valid price data found for ticker {ticker.ticker if hasattr(ticker, 'ticker') else str(ticker)} on {date.date()}."
+            )
+
+        _PRICE_CACHE[key] = round(df.loc[date]["Close"], 2)
     return _PRICE_CACHE[key]
+
+
+def download_prices_for_date(
+    tickers: Iterable[str], date: datetime.date, retry_delay: float = 1.0
+) -> Dict[str, float]:
+    """Download closing prices for all ``tickers`` on ``date`` using a single
+    :func:`yf.download` call. Values are cached and returned as a mapping.
+    """
+
+    uniq = sorted(set(str(t).upper() for t in tickers))
+    missing = [t for t in uniq if (t, date) not in _PRICE_CACHE]
+    if missing:
+        if date.weekday() >= 5:
+            raise ValueError(f"{date} is not a trading day")
+
+        attempts = 0
+        while True:
+            try:
+                df = yf.download(
+                    missing,
+                    start=date,
+                    end=date + timedelta(days=1),
+                    progress=False,
+                    group_by="ticker",
+                )
+                break
+            except Exception:
+                attempts += 1
+                if attempts >= 2:
+                    raise
+                time.sleep(retry_delay)
+
+        for t in missing:
+            data = df if len(missing) == 1 else df[t]
+            if date not in data.index:
+                raise ValueError(f"No price data for {t} on {date}")
+            price = round(data.loc[date]["Close"], 2)
+            _PRICE_CACHE[(t, date)] = price
+
+    return {t: _PRICE_CACHE[(t, date)] for t in uniq}
+
+
+def download_price(ticker: str, date: datetime.date, retry_delay: float = 1.0) -> float:
+    """Convenience wrapper around :func:`download_prices_for_date` for a single ticker."""
+
+    return download_prices_for_date([ticker], date, retry_delay)[ticker]


### PR DESCRIPTION
## Summary
- enforce trading-day checks and single-day downloads in Yahoo utilities

## Testing
- `pytest -q`
- `python -m py_compile ctbus_finance/account_holding.py ctbus_finance/db.py ctbus_finance/yahoo_finance.py`
- `python - <<'EOF'
from ctbus_finance.yahoo_finance import download_prices_for_date
print('ok', callable(download_prices_for_date))
EOF`


------
https://chatgpt.com/codex/tasks/task_e_684af594bc508323a041f83488ab174c