### PR TITLE
Enhance dashboard with charts

### DIFF
--- a/ctbus_finance/flask_app.py
+++ b/ctbus_finance/flask_app.py
@@ -3,7 +3,7 @@ from ctbus_finance.views import (
     get_accounts,
     get_credit_cards,
     get_net_value,
-    get_monthly_net_worth,
+    get_monthly_summary,
 )
 
 
@@ -13,8 +13,8 @@ def create_app() -> Flask:
     @app.route("/")
     def index():
         net = get_net_value()
-        trend = get_monthly_net_worth()
-        return render_template("index.html", net_value=net, trend=trend)
+        trend = get_monthly_summary()
+        return render_template("index.html", net_value=net, summary=trend)
 
     @app.route("/accounts")
     def accounts():

--- a/ctbus_finance/templates/accounts.html
+++ b/ctbus_finance/templates/accounts.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <title>Accounts</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
     <h1>Accounts</h1>
@@ -16,6 +17,19 @@
         </tr>
         {% endfor %}
     </table>
+    <canvas id="accountsChart" width="600" height="300"></canvas>
+    <script>
+        const accLabels = {{ accounts | map(attribute=0) | list | tojson }};
+        const accData = {{ accounts | map(attribute=3) | list | tojson }};
+        new Chart(document.getElementById('accountsChart'), {
+            type: 'bar',
+            data: {
+                labels: accLabels,
+                datasets: [{label: 'Total Value', data: accData, backgroundColor: 'blue'}]
+            },
+            options: {scales: {y: {beginAtZero: true}}}
+        });
+    </script>
     <p><a href="{{ url_for('index') }}">Home</a></p>
 </body>
 </html>

--- a/ctbus_finance/templates/credit_cards.html
+++ b/ctbus_finance/templates/credit_cards.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <title>Credit Cards</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
     <h1>Credit Cards</h1>
@@ -16,6 +17,19 @@
         </tr>
         {% endfor %}
     </table>
+    <canvas id="ccChart" width="600" height="300"></canvas>
+    <script>
+        const ccLabels = {{ credit_cards | map(attribute=0) | list | tojson }};
+        const ccData = {{ credit_cards | map(attribute=3) | list | tojson }};
+        new Chart(document.getElementById('ccChart'), {
+            type: 'bar',
+            data: {
+                labels: ccLabels,
+                datasets: [{label: 'Balance', data: ccData, backgroundColor: 'red'}]
+            },
+            options: {scales: {y: {beginAtZero: true}}}
+        });
+    </script>
     <p><a href="{{ url_for('index') }}">Home</a></p>
 </body>
 </html>

--- a/ctbus_finance/templates/index.html
+++ b/ctbus_finance/templates/index.html
@@ -2,18 +2,32 @@
 <html>
 <head>
     <title>ctbus_finance Dashboard</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
     <h1>ctbus_finance Dashboard</h1>
     <p>Net Worth: {{ net_value }}</p>
 
-    <h2>Net Worth Trend</h2>
-    <table>
-        <tr><th>Month</th><th>Net Worth</th></tr>
-        {% for month, value in trend %}
-        <tr><td>{{ month }}</td><td>{{ value }}</td></tr>
-        {% endfor %}
-    </table>
+    <h2>Monthly Trends</h2>
+    <canvas id="trendChart" width="600" height="300"></canvas>
+    <script>
+        const labels = {{ summary | map(attribute=0) | list | tojson }};
+        const netData = {{ summary | map(attribute=1) | list | tojson }};
+        const cashData = {{ summary | map(attribute=2) | list | tojson }};
+        const ccData = {{ summary | map(attribute=3) | list | tojson }};
+        new Chart(document.getElementById('trendChart'), {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [
+                    {label: 'Net Worth', data: netData, borderColor: 'blue', fill: false},
+                    {label: 'Cash Value', data: cashData, borderColor: 'green', fill: false},
+                    {label: 'Credit Card Spending', data: ccData, borderColor: 'red', fill: false}
+                ]
+            },
+            options: {scales: {y: {beginAtZero: true}}}
+        });
+    </script>
 
     <p>
         <a href="{{ url_for('accounts') }}">Accounts</a> |


### PR DESCRIPTION
## Summary
- add Chart.js graphs for accounts, credit cards, and dashboard
- compute monthly summaries for net worth, cash, and credit spending

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1f18a48c83238d151bd2fe292e2a