### PR TITLE
Implement Yahoo price lookups

### DIFF
--- a/ctbus_finance/ingest.py
+++ b/ctbus_finance/ingest.py
@@ -82,9 +82,18 @@ def load_account_holdings(fp: Path, default_date: date) -> List[AccountHolding]:
             lookups.setdefault(pd_val, set()).add(row["holding_id"])
 
     # Download prices for the dates that need them
-    # NOT IMPLEMENTED
-    print(lookups)
-    assert False
+    if lookups:
+        from ctbus_finance import yahoo_finance
+
+        for dt, symbols in lookups.items():
+            prices = yahoo_finance.download_prices_for_date(symbols, dt)
+            for row in rows:
+                if row["holding_id"] not in symbols:
+                    continue
+                if row["date"] == dt and row["price"] is None:
+                    row["price"] = prices.get(row["holding_id"])
+                if row.get("purchase_date") == dt and row["purchase_price"] is None:
+                    row["purchase_price"] = prices.get(row["holding_id"])
 
     holdings: List[AccountHolding] = []
     for row in rows:

--- a/ctbus_finance/yahoo_finance.py
+++ b/ctbus_finance/yahoo_finance.py
@@ -1,0 +1,94 @@
+"""Helper functions for retrieving prices from Yahoo Finance.
+
+This module provides a thin wrapper around :mod:`yfinance` that caches
+responses and tries to minimise the number of requests in order to avoid
+hitting Yahoo's rate limits.  Only a subset of the larger module that used to
+live here is implemented as we really only need bulk daily price lookups when
+ingesting account holdings.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import date, timedelta
+from typing import Dict, Iterable
+
+import yfinance as yf
+from yfinance.exceptions import YFRateLimitError
+
+# Cache of {(ticker, date): price}.  Prices are stored rounded to two decimal
+# places to avoid small floating point differences from yfinance.
+_PRICE_CACHE: Dict[tuple[str, date], float] = {}
+
+
+def download_prices_for_date(
+    tickers: Iterable[str], on_date: date, max_retries: int = 5
+) -> Dict[str, float]:
+    """Return closing prices for ``tickers`` on ``on_date``.
+
+    ``yfinance.download`` normally spawns several threads which can easily hit
+    Yahoo's rate limits when requesting data for many symbols.  To keep things
+    simple and predictable we fetch all tickers in a single request with
+    ``threads=False`` and retry a few times if we encounter ``YFRateLimitError``.
+    Results are cached so repeated calls for the same ticker/date pair do not
+    trigger additional network requests.
+    """
+
+    unique = sorted({t.upper() for t in tickers})
+    missing = [t for t in unique if (t, on_date) not in _PRICE_CACHE]
+    if missing:
+        if on_date.weekday() >= 5:
+            # Markets are closed on weekends
+            raise ValueError(f"{on_date} is not a trading day")
+
+        attempts = 0
+        while True:
+            try:
+                df = yf.download(
+                    missing,
+                    start=on_date,
+                    end=on_date + timedelta(days=1),
+                    progress=False,
+                    group_by="ticker",
+                    actions=False,
+                    auto_adjust=False,
+                    threads=False,
+                )
+                break
+            except YFRateLimitError:
+                attempts += 1
+                if attempts >= max_retries:
+                    raise
+                time.sleep(2**attempts)
+            except Exception:
+                attempts += 1
+                if attempts >= max_retries:
+                    raise
+                time.sleep(1)
+
+        for t in missing:
+            data = df if len(missing) == 1 else df[t]
+            if on_date not in data.index:
+                # Yahoo occasionally omits prices (holidays etc.).  Skip silently.
+                continue
+            price = round(float(data.loc[on_date]["Close"]), 2)
+            _PRICE_CACHE[(t, on_date)] = price
+
+    return {
+        t: _PRICE_CACHE[(t, on_date)] for t in unique if (t, on_date) in _PRICE_CACHE
+    }
+
+
+def download_price(ticker: str, on_date: date) -> float:
+    """Convenience wrapper for :func:`download_prices_for_date`."""
+
+    prices = download_prices_for_date([ticker], on_date)
+    if ticker.upper() not in prices:
+        raise ValueError(f"No price data for {ticker} on {on_date}")
+    return prices[ticker.upper()]
+
+
+def clear_cache() -> None:
+    """Remove all cached price data."""
+
+    _PRICE_CACHE.clear()


### PR DESCRIPTION
## Summary
- implement `yahoo_finance` helper for downloading daily prices using yfinance
- fetch missing prices during account holding ingest via new helper

## Testing
- `black -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2fe93fcc8323817329bd2596c809