### PR TITLE
Persist price cache and batch Yahoo requests

### DIFF
--- a/ctbus_finance/models.py
+++ b/ctbus_finance/models.py
@@ -120,3 +120,14 @@ class CreditCardHolding(Base):
     @property
     def total_value(self):
         return (self.rewards if self.rewards else 0) - self.balance
+
+
+class PriceCache(Base):
+    """Persisted price data fetched from Yahoo Finance."""
+
+    __tablename__ = "price_cache"
+
+    symbol = Column(String, primary_key=True, nullable=False)
+    date = Column(Date, primary_key=True, nullable=False)
+    price = Column(Float, nullable=False)
+


### PR DESCRIPTION
## Summary
- add a `PriceCache` model for persisting fetched prices
- batch Yahoo requests and use exponential backoff with more retries
- clear persistent cache when clearing in-memory cache

## Testing
- `python -m compileall -q ctbus_finance`

------
https://chatgpt.com/codex/tasks/task_e_684b6b074e708323b759e88cc28c7cb4