### PR TITLE
Add MonthReports aggregation for report net values

### DIFF
--- a/ctbus_finance/__init__.py
+++ b/ctbus_finance/__init__.py
@@ -4,6 +4,7 @@ __version__ = "0.1.0"
 
 from .reports import (
     Report,
+    MonthReports,
     HSAReport,
     Four03bReport,
     RothIRAReport,
@@ -29,6 +30,7 @@ from .reports import (
 
 __all__ = [
     "Report",
+    "MonthReports",
     "HSAReport",
     "Four03bReport",
     "RothIRAReport",

--- a/ctbus_finance/reports.py
+++ b/ctbus_finance/reports.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import date
 from pathlib import Path
 from typing import Iterable
 
@@ -17,6 +18,33 @@ class Report:
         reader = PdfReader(str(self.path))
         texts: Iterable[str] = (page.extract_text() or "" for page in reader.pages)
         return "\n".join(texts).strip()
+
+    @property
+    def net_value(self) -> float:
+        """Net monetary value represented by this report."""
+        return 0.0
+
+
+class MonthReports:
+    """Collection of reports for a specific month."""
+
+    def __init__(self, month: date, reports: Iterable[Report] | None = None) -> None:
+        self.month = month
+        self._reports = list(reports) if reports else []
+
+    def add(self, report: Report) -> None:
+        """Add a report to the collection."""
+        self._reports.append(report)
+
+    @property
+    def reports(self) -> list[Report]:
+        """Return the list of stored reports."""
+        return list(self._reports)
+
+    @property
+    def net_value(self) -> float:
+        """Aggregate net value of all contained reports."""
+        return sum(r.net_value for r in self._reports)
 
 
 class HSAReport(Report):

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,3 +1,4 @@
+from datetime import date
 from pathlib import Path
 import sys
 
@@ -9,6 +10,7 @@ sys.path.insert(0, str(ROOT))
 
 from ctbus_finance import (
     Report,
+    MonthReports,
     HSAReport,
     Four03bReport,
     RothIRAReport,
@@ -78,3 +80,45 @@ def test_subclasses():
     }
     for subclass, parent in platform_map.items():
         assert issubclass(subclass, parent)
+
+
+def test_net_value_property(tmp_path):
+    pdf = tmp_path / "blank.pdf"
+    create_blank_pdf(pdf)
+
+    account_classes = [
+        HSAReport,
+        Four03bReport,
+        RothIRAReport,
+        BrokerageReport,
+        CheckingReport,
+        SavingsReport,
+        CreditCardReport,
+        CryptoWalletReport,
+        CashReport,
+        DigitalWalletReport,
+    ]
+
+    for cls in account_classes:
+        report = cls(pdf)
+        assert isinstance(report.net_value, (int, float))
+
+
+def test_month_reports_aggregate(tmp_path):
+    pdf = tmp_path / "blank.pdf"
+    create_blank_pdf(pdf)
+
+    class DummyReport(Report):
+        def __init__(self, value: float) -> None:
+            super().__init__(pdf)
+            self._value = value
+
+        @property
+        def net_value(self) -> float:
+            return self._value
+
+    january = MonthReports(date(2024, 1, 1))
+    january.add(DummyReport(10))
+    january.add(DummyReport(15))
+
+    assert january.net_value == 25


### PR DESCRIPTION
## Summary
- add `net_value` property to base `Report` class
- introduce `MonthReports` to sum report values per month
- test monthly aggregation and presence of net value on reports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6892a099f078832386e8cfe0162d0894