### PR TITLE
Update importers for Beancount 3

### DIFF
--- a/ctbus_finance/importers/capitalone_credit_card.py
+++ b/ctbus_finance/importers/capitalone_credit_card.py
@@ -7,7 +7,7 @@ from beancount.core import amount
 from beancount.core import data
 from beancount.core import flags
 from beancount.core import number as beancount_number
-from beancount.ingest import importer
+from beangulp import importer
 
 _COLUMN_TRANS_DATE = "Transaction Date"
 _COLUMN_DATE = "Posted Date"

--- a/ctbus_finance/importers/capitalone_deposit_account.py
+++ b/ctbus_finance/importers/capitalone_deposit_account.py
@@ -7,7 +7,7 @@ from beancount.core import amount
 from beancount.core import data
 from beancount.core import flags
 from beancount.core import number as beancount_number
-from beancount.ingest import importer
+from beangulp import importer
 
 
 _COLUMN_ACCOUNT_NO = "Account Number"

--- a/ctbus_finance/importers/fidelity.py
+++ b/ctbus_finance/importers/fidelity.py
@@ -3,7 +3,7 @@ import datetime
 import re
 import titlecase
 from beancount.core import amount, data, flags, number as beancount_number, position
-from beancount.ingest import importer
+from beangulp import importer
 
 
 _COLUMN_DATE = "Run Date"

--- a/ctbus_finance/importers/venmo.py
+++ b/ctbus_finance/importers/venmo.py
@@ -4,7 +4,7 @@ from beancount.core import amount
 from beancount.core import data
 from beancount.core import flags
 from beancount.core import number as beancount_number
-from beancount.ingest import importer
+from beangulp import importer
 
 
 _COLUMN_CAT = "Cat"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ description = "Importers that convert financial statements into Beancount entrie
 dynamic = ["version"]
 dependencies = [
     "beancount~=3.2",
+    "beangulp~=0.2",
     "fava~=1.26",
     "titlecase~=2.4",
 ]


### PR DESCRIPTION
## Summary
- switch the custom importers to use `beangulp.importer.ImporterProtocol` now that Beancount 3 no longer provides `beancount.ingest`
- add a runtime dependency on Beangulp so the importers can be loaded alongside Beancount 3

## Testing
- python -m compileall ctbus_finance

------
https://chatgpt.com/codex/tasks/task_e_68dc0c8ac62c8323b4ccf26d77a62b0e